### PR TITLE
new: テーマのstyle.cssを自動生成するコマンドを追加

### DIFF
--- a/frp-plugins/style.css
+++ b/frp-plugins/style.css
@@ -1,0 +1,5 @@
+/*
+Theme Name: <%= name %>
+Version: <%= version %>
+Text Domain: <%= domain %>
+*/

--- a/frp-plugins/wp-theme-style.js
+++ b/frp-plugins/wp-theme-style.js
@@ -1,0 +1,22 @@
+'use strict';
+const fs = require('fs-extra');
+const Rx = require('rxjs');
+const ejs = require('ejs');
+
+module.exports = function (argv, config) {
+  const filePath = './frp-plugins/style.css';
+  const outputPath = `${config.wp.dest}/style.css`;
+
+  return Rx.Observable.create((observer) => {
+
+    ejs.renderFile(filePath, config.wp.params, (err, str) => {
+      if(err) return observer.error(err);
+
+      fs.outputFile(outputPath, str, (err) => {
+        if(err) observer.error(err);
+        observer.next(outputPath);
+      });
+    });
+
+  });
+};

--- a/frp.config.js
+++ b/frp.config.js
@@ -1,9 +1,12 @@
 'use strict';
+const packageJSON = require('./package.json');
 
 // https://github.com/frontainer/frontplate-cli/wiki/6.%E8%A8%AD%E5%AE%9A
 module.exports = function (production) {
-  global.FRP_SRC  = 'src/sampletheme';
-  global.FRP_DEST = 'wp/wp-content/themes/sampletheme';
+  global.THEME_NAME   = 'Sample Theme';
+  global.THEME_DOMAIN = 'sampletheme';
+  global.FRP_SRC  = `src/${THEME_DOMAIN}`;
+  global.FRP_DEST = `wp/wp-content/themes/${THEME_DOMAIN}`;
   return {
     clean: {
       src: `${FRP_DEST}/assets`
@@ -15,6 +18,15 @@ module.exports = function (production) {
     },
     copy: {},
     sprite: [],
-    test: {}
+    test: {},
+    // theme直下のstyle.cssの自動生成タスクへ渡すパラメータ
+    wp: {
+      dest: FRP_DEST,
+      params: {
+        name: THEME_NAME,
+        version: packageJSON.version,
+        domain: THEME_DOMAIN
+      }
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "npm run build && npm run serve",
     "test": "frp build",
+    "wpstyle": "frp exe frp-plugins/wp-theme-style.js",
     "build": "docker-compose build && frp build",
     "serve": "run-p server:*",
     "server:web": "frp serve",

--- a/wp/wp-content/themes/sampletheme/style.css
+++ b/wp/wp-content/themes/sampletheme/style.css
@@ -1,5 +1,5 @@
 /*
 Theme Name: Sample Theme
-Version: 0.0.0
+Version: 0.1.0
 Text Domain: sampletheme
 */


### PR DESCRIPTION
`npm run wpstyle` でtheme直下にstyle.cssを生成するようにしてみました。
リリース時に `npm version patch` とか叩いた後に上記コマンドも実行する感じなのかなと思っています。