### PR TITLE
Add build script using Frontplate CLI on Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,48 @@
-# wordpress-frontplate
+# Wordpress Boilerplate for Frontplate CLI
 
 フロントエンド開発の効率を上げるテンプレートのWordpress版の派生版です。
 
 [CHANGELOG](https://github.com/frontainer/wp-frontplate/blob/master/CHANGELOG.md)
 
-## Dependence
+## Building Frontend Resources
 
-* [NodeJS](https://nodejs.org/) 5.0以上
-* [frontplate-cli](https://www.npmjs.com/package/frontplate-cli)
-* [Docker for Mac](https://docs.docker.com/docker-for-mac/) または [Docker for Windows](https://docs.docker.com/docker-for-windows/)
+🇬🇧 To build frontend resources, please run following command at the project root directory.
+
+Frontend source files need to be built before publishing since they are not written as directly compatible with browsers.
+
+Note that you need Docker to be installed on your machine to proceed this.
+
+🇯🇵 フロントエンドリソースをビルドするには、プロジェクトルートディレクトリで下記のコマンドを実行してください。
+
+フロントエンドのソースファイルはブラウザに対する直接的な互換性を持たないため、公開前にビルドを実行する必要があります。
+
+この処理を実行するためにはお使いの端末に Docker がインストールされている必要があります。
+
+```sh
+sh scripts/build.sh
+```
+
+## Launching Testing Environment Locally
+
+🇬🇧 To launch a testing environment on your local machine, please run following command at the project root directory.
+
+This repository includes Docker Compose configuration file which lets you launch a virtual machine (container) to sandboxing and testing the application.
+
+This feature simplily relys on Docker and Docker Compose so please refer to their documentation for detailed instructions and trouble shooting.
+
+Note that this process also requires you to install Docker on your machine.
+
+🇯🇵 テスト環境をローカルで起動するには、プロジェクトルートディレクトリで下記のコマンドを実行してください。
+
+このリポジトリには Docker Compose の設定が含まれており、あなたの端末上で仮想マシン (コンテナ) を立ち上げ、安全な環境でアプリケーションのテストを可能にします。
+
+この機能はシンプルに Docker および Docker Compose に依存しているので、詳細な利用方法およびトラブルシューティングはこれらの公式ドキュメントをご参照ください。
+
+この処理もまた Docker のインストールを必要とします。
+
+```sh
+docker-compose up
+```
 
 ## Get Started
 
@@ -34,7 +68,7 @@ phpバージョンの初期値は7.1になります。php5.6を利用したい�
 ```
 wordpress:
   image: liginccojp/wordpress:php5.6
-  
+
 ```
 
 `$ npm start`
@@ -65,5 +99,3 @@ Run npm scripts command, below.
 package.jsonのバージョン情報で、WordPressテーマのstyle.cssを更新します。
 これにより、WordPressテーマからpackage.jsonのバージョン情報を参照できるようになります。
 静的ファイルのキャッシュコントロール用のパラメータなどとして使えます。
-
-

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Note that you need Docker to be installed on your machine to proceed this.
 
 ```sh
 sh scripts/build.sh
+
+# More options available:
+# sh scripts/build.sh --help
 ```
 
 ## Launching Testing Environment Locally

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Config
+BUILDER_IMAGE=liginccojp/frontplate-cli-docker:node8-npm4-frp4
+
+# Nasty hack to emurate `realpath` on OSX
+SCRIPT_PATH=`perl -e 'use Cwd "abs_path";print abs_path(shift)' $0`
+
+# Color codes
+# check if stdout is a terminal...
+if test -t 1; then
+    # see if it supports colors...
+    ncolors=$(tput colors)
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        BOLD="$(tput bold)"
+        # UNDERLINE="$(tput smul)"
+        # STANDOUT="$(tput smso)"
+        NORMAL="$(tput sgr0)"
+        # BLACK="$(tput setaf 0)"
+        RED="$(tput setaf 1)"
+        # GREEN="$(tput setaf 2)"
+        # YELLOW="$(tput setaf 3)"
+        # BLUE="$(tput setaf 4)"
+        # MAGENTA="$(tput setaf 5)"
+        CYAN="$(tput setaf 6)"
+        # WHITE="$(tput setaf 7)"
+    fi
+fi
+
+# chekking command installation
+for COMMAND in docker; do
+    if ! COMMAND_LOCATION="$(type -p "${COMMAND}")" || [[ -z ${COMMAND_LOCATION} ]]; then
+        echo "${RED}${BOLD}ERROR:${NORMAL} ${RED}command not found: ${COMMAND}${NORMAL}"
+        echo "You need to install Docker to use this build script"
+        exit 1
+    fi
+done
+
+echo "${CYAN}Pulling the latest docker image...${NORMAL}"
+
+docker pull ${BUILDER_IMAGE}
+
+echo "${CYAN}Running the builder application inside the docker container...${NORMAL}"
+
+docker run \
+    -it --rm \
+    -v $(dirname ${SCRIPT_PATH})/..:/workspace:rw \
+    ${BUILDER_IMAGE}
+
+exit 0

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,29 +1,28 @@
 #!/usr/bin/env bash
 
+#-------------------------------------------------------------------------------
 # Config
+
 BUILDER_IMAGE=liginccojp/frontplate-cli-docker:node8-npm4-frp4
+
+#-------------------------------------------------------------------------------
+# Helper
 
 # Nasty hack to emurate `realpath` on OSX
 SCRIPT_PATH=`perl -e 'use Cwd "abs_path";print abs_path(shift)' $0`
 
 # Color codes
+NORMAL=''
+RED=''
+CYAN=''
 # check if stdout is a terminal...
 if test -t 1; then
     # see if it supports colors...
     ncolors=$(tput colors)
     if test -n "$ncolors" && test $ncolors -ge 8; then
-        BOLD="$(tput bold)"
-        # UNDERLINE="$(tput smul)"
-        # STANDOUT="$(tput smso)"
         NORMAL="$(tput sgr0)"
-        # BLACK="$(tput setaf 0)"
         RED="$(tput setaf 1)"
-        # GREEN="$(tput setaf 2)"
-        # YELLOW="$(tput setaf 3)"
-        # BLUE="$(tput setaf 4)"
-        # MAGENTA="$(tput setaf 5)"
         CYAN="$(tput setaf 6)"
-        # WHITE="$(tput setaf 7)"
     fi
 fi
 
@@ -36,15 +35,49 @@ for COMMAND in docker; do
     fi
 done
 
-echo "${CYAN}Pulling the latest docker image...${NORMAL}"
+#-------------------------------------------------------------------------------
+# Help Message
 
-docker pull ${BUILDER_IMAGE}
+if [ "$1" = "--help" ]; then
+  echo "${BOLD}Frontend Resource Build Helper Script${NORMAL}"
+  echo ""
+  echo "${CYAN}Run default build:${NORMAL}        $(basename $0)"
+  echo "${CYAN}Run specific command:${NORMAL}     $(basename $0) command [options [...]]"
+  echo "${CYAN}Pull latest Docker image:${NORMAL} $(basename $0) pull"
+  exit 0
+fi
 
-echo "${CYAN}Running the builder application inside the docker container...${NORMAL}"
+#-------------------------------------------------------------------------------
+# Pull Latest Docker Image
 
-docker run \
+if [ "$1" = "pull" ]; then
+  echo "${CYAN}Pulling the latest docker image...${NORMAL}"
+  if ! docker pull ${BUILDER_IMAGE}; then
+    echo "${RED}${BOLD}ERROR:${NORMAL}${RED} Failed to pull the docker image: ${BUILDER_IMAGE}${NORMAL}"
+    exit 1
+  fi
+  exit 0
+fi
+
+#-------------------------------------------------------------------------------
+# Runnning Command on Docker Container
+
+if [ $# -ne 0 ]; then
+  echo "${CYAN}Running the command \`$@\` inside the docker container...${NORMAL}"
+else
+  echo "${CYAN}Running the builder application inside the docker container...${NORMAL}"
+fi
+
+
+if ! docker run \
     -it --rm \
     -v $(dirname ${SCRIPT_PATH})/..:/workspace:rw \
-    ${BUILDER_IMAGE}
+    ${BUILDER_IMAGE} \
+    $@; then
+  echo "${RED}${BOLD}ERROR:${NORMAL}${RED} Failed to execute command \`$@\` on the container${NORMAL}"
+  exit 1
+fi
 
 exit 0
+
+#-------------------------------------------------------------------------------


### PR DESCRIPTION
This adds a script file that builds the frontend resources using Frontplate CLI running on Docker container.

The major strategy of this is to avoid the compatibility issues across the various machines and provides a single, solid and constant immutable virtualized build environment with the power of Docker.

## Usage

```sh
sh scripts/build.sh [options [...]]
```

### Options

| Options | Description |
|:-|:-|
| _(no options)_ | Runs default build process<br />(`npm install` + `frp build --production`) |
| `command [options [...]]` | Runs specified command in the container |
| `pull` | Pulls the latest Docker image  |
| `--help` | Shows help message  |

## Docker Image Details
### Image

[`liginccojp/frontplate-cli-docker:node8-npm4-frp4`](https://hub.docker.com/r/liginccojp/frontplate-cli-docker/)

### Applications in the Image

| Application | Version |
|:-|:-|
| Frontplate CLI | 4.x  |
| NPM | 4.x  |
| Node.js | 8.x  |