### PR TITLE
ファイルキャッシュ対策

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ guide
 !/wp/wp-content/themes/
 /wp/wp-content/themes/**/assets/
 /wp/wp-content/themes/**/images/
+/wp/wp-content/themes/**/anticache.json
 !/wp/wp-content/languages/
 /wp/wp-content/languages/*
 !/wp/wp-content/languages/plugins/

--- a/config/style.config.production.js
+++ b/config/style.config.production.js
@@ -4,6 +4,10 @@ const merge = require('webpack-merge');
 module.exports = merge(conf, {
   sourceMap: false,
   plugins: [  // postcssプラグイン
-    require('postcss-csso')()
+    require('postcss-csso')(),
+    require('postcss-cachebuster')({
+      imagesPath : `/${FRP_DEST}/assets/images`,
+      cssPath : `/${FRP_DEST}/assets/css`
+    })
   ]
 });

--- a/frp-plugins/anticache.js
+++ b/frp-plugins/anticache.js
@@ -1,0 +1,32 @@
+'use strict';
+const path = require('path');
+const fs = require('fs-extra');
+const Rx = require('rxjs');
+
+module.exports = function (argv, config) {
+  const randomStr = getRandomStr();
+  const outputPath = `${config.anticache.dest}/anticache.json`;
+
+  const json = {
+    "anticache": randomStr
+  };
+
+  return Rx.Observable.create((observer) => {
+    fs.outputFile(outputPath, JSON.stringify(json), err => {
+      if(err) return observer.error(err);
+    });
+  });
+};
+
+function getRandomStr(len = 6){
+  const str = '0123456789abcdefghijklmnopqrstuvwxyz';
+  const parts = str.split('');
+  const result = [];
+
+  for(let i = 0; i < len; i++){
+    const random = parseInt(Math.random() * parts.length);
+    result[i] = parts[random];
+  }
+
+  return result.join('');
+}

--- a/frp.config.js
+++ b/frp.config.js
@@ -28,6 +28,9 @@ module.exports = function (production) {
         version: packageJSON.version,
         domain: THEME_DOMAIN
       }
+    },
+    anticache: {
+      dest: FRP_DEST
     }
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -377,6 +377,12 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
+    "canonical-path": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/canonical-path/-/canonical-path-0.0.2.tgz",
+      "integrity": "sha1-4x65N6jJPuKgHfGDl5RyGQKHRXQ=",
+      "dev": true
+    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -567,10 +573,22 @@
         "ansi-regex": "2.1.1"
       }
     },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
     "invariant": {
@@ -634,6 +652,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-base64": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.8.tgz",
+      "integrity": "sha512-hm2nYpDrwoO/OzBhdcqs/XGT6XjSuSSCVEpia+Kl2J6x4CYt5hISlVL/AYU1khoDXv0AQVgxtdJySb9gjAn56Q==",
       "dev": true
     },
     "js-tokens": {
@@ -782,6 +806,16 @@
         "error-ex": "1.3.1"
       }
     },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "dev": true,
+      "requires": {
+        "process": "0.11.10",
+        "util": "0.10.4"
+      }
+    },
     "path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
@@ -831,6 +865,47 @@
       "requires": {
         "pinkie": "2.0.4"
       }
+    },
+    "postcss": {
+      "version": "5.2.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+      "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "js-base64": "2.4.8",
+        "source-map": "0.5.7",
+        "supports-color": "3.2.3"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        }
+      }
+    },
+    "postcss-cachebuster": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-cachebuster/-/postcss-cachebuster-0.1.5.tgz",
+      "integrity": "sha1-nEoQ4DqJh6NIKJE6gD7sqixiqko=",
+      "dev": true,
+      "requires": {
+        "canonical-path": "0.0.2",
+        "chalk": "1.1.3",
+        "path": "0.12.7",
+        "postcss": "5.2.18"
+      }
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "dev": true
     },
     "ps-tree": {
       "version": "1.1.0",
@@ -891,6 +966,12 @@
         "array-reduce": "0.0.0",
         "jsonify": "0.0.0"
       }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
     },
     "spdx-correct": {
       "version": "1.0.2",
@@ -977,6 +1058,15 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
+    },
+    "util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-stage-2": "^6.24.1",
     "eslint-plugin-filenames": "^1.2.0",
-    "npm-run-all": "^3.1.0"
+    "npm-run-all": "^3.1.0",
+    "postcss-cachebuster": "^0.1.5"
   },
   "scripts": {
     "start": "npm run build && npm run serve",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,10 @@
     "serve": "run-p server:*",
     "server:web": "frp serve",
     "server:docker": "docker-compose up",
-    "production": "frp build -p",
+    "production": "frp build -p && npm run anticache",
     "changelog": "conventional-changelog -p eslint -i CHANGELOG.md -w -s -r 0",
-    "sqldump": "sh scripts/mysqldump.sh"
+    "sqldump": "sh scripts/mysqldump.sh",
+    "anticache": "frp exe frp-plugins/anticache.js"
   },
   "private": true
 }

--- a/wp/wp-content/themes/sampletheme/functions/common.php
+++ b/wp/wp-content/themes/sampletheme/functions/common.php
@@ -154,13 +154,23 @@ function get_primary_term( $post_id, $tax = "category" ) {
 function add_anticache( $file ) {
   // anticache.jsonがある場合
   if('' !== (string) ANTICACHE_HASH){
+    // svg fragment identifierの可能性を考慮
+    $parts = explode('#', $file);
+    $fragment = '';
+
+    // #が含まれている場合
+    if(strpos($file, '#') !== false){
+      $fragment = "#{$parts[1]}";
+    }
+
     // ?が含まれていない場合
-    if(strpos($file, '?') === false){
+    if(strpos($parts[0], '?') === false){
       $delimeter = '?';
     } else {
       $delimeter = '&';
     }
-    $file = "{$file}{$delimeter}_=" . ANTICACHE_HASH;
+
+    $file = "{$parts[0]}{$delimeter}_=" . ANTICACHE_HASH . $fragment;
   }
 
   return $file;

--- a/wp/wp-content/themes/sampletheme/functions/common.php
+++ b/wp/wp-content/themes/sampletheme/functions/common.php
@@ -144,3 +144,24 @@ function get_primary_term( $post_id, $tax = "category" ) {
     return array();
   }
 }
+
+/**
+ * 静的ファイルのキャッシュ対策としてファイルにクエリパラメータを追記して返します
+ *
+ * @param [string] $file
+ * @return string
+ */
+function add_anticache( $file ) {
+  // anticache.jsonがある場合
+  if('' !== (string) ANTICACHE_HASH){
+    // ?が含まれていない場合
+    if(strpos($file, '?') === false){
+      $delimeter = '?';
+    } else {
+      $delimeter = '&';
+    }
+    $file = "{$file}{$delimeter}_=" . ANTICACHE_HASH;
+  }
+
+  return $file;
+}

--- a/wp/wp-content/themes/sampletheme/functions/path.php
+++ b/wp/wp-content/themes/sampletheme/functions/path.php
@@ -7,7 +7,7 @@ function get_current_uri() {
 }
 
 function resolve_asset_uri( $subpath = '' ) {
-  return esc_url( rtrim( get_template_directory_uri(), '/' ) . '/static/assets/' . ltrim( $subpath, '/' ) );
+  return esc_url( add_anticache( rtrim( get_template_directory_uri(), '/' ) . '/assets/' . ltrim( $subpath, '/' ) ) );
 }
 
 function resolve_url( $path = '' ) {

--- a/wp/wp-content/themes/sampletheme/inc/define.php
+++ b/wp/wp-content/themes/sampletheme/inc/define.php
@@ -17,3 +17,16 @@ define( 'ITEM_URL', get_stylesheet_directory_uri() . '/' );
 // ノーイメージパス
 define( 'NOIMAGE', ITEM_URL . 'assets/images/noimage.png' );
 
+$load_release_hash = function(){
+  $map = get_template_directory() . '/anticache.json';
+  if(! file_exists( $map )) {
+    return '';
+  }
+  $content = json_decode( file_get_contents( $map ));
+  if(! is_object($content) || ! isset($content->anticache)) {
+    return '';
+  }
+  return $content->anticache;
+};
+
+define( 'ANTICACHE_HASH', $load_release_hash());


### PR DESCRIPTION
WordPressテンプレートにて、`resolve_asset_uri`関数で画像などのファイルを指定し、
`npm run production`コマンドを打つと、ファイルにランダム文字列を付与。
CSSファイル内の画像については、`postcss-cachebuster`パッケージが文字列を付与。